### PR TITLE
Fixes CurrentArtwork

### DIFF
--- a/squeezebox.js
+++ b/squeezebox.js
@@ -342,7 +342,7 @@ function completePlayer(device) {
     device.player.runTelnetCmd("artist ?");
     device.player.runTelnetCmd("album ?");
     device.player.runTelnetCmd("mode ?");
-    device.player.runTelnetCmd('status 0 1 tags:K'); // get the artwork URL
+    device.player.runTelnetCmd('status - 1 tags:K'); // get the artwork URL
 }
 
 function createStateObject(commonInfo) {
@@ -371,7 +371,7 @@ function processSqueezeboxEvents(device, eventData) {
                 device.elapsedTimer = null;
                 device.player.runTelnetCmd('time ?');
                 device.searchingArtwork = true;
-                device.player.runTelnetCmd('status 0 1 tags:K'); // get the artwork URL
+                device.player.runTelnetCmd('status - 1 tags:K'); // get the artwork URL
             }
         }
         return;


### PR DESCRIPTION
The CurrentArtwork mistakenly displays only the Artwork of the current Playlist's first song. With the change it will display the the current song's Artwork directly after every songschange.

The official CLI Reference tells us: "Index (first item is 0) of the playlist entry in the player playlist. Unless <start> is "-", the first returned instance of this field is equal to start. If <start> is "-", the first returned instance of this field contains the index of the currently playing song in the player playlist."